### PR TITLE
Enable clustering to all caches

### DIFF
--- a/src/main/java/org/infinispan/wfswarm/configuration/InfinispanConfiguration.java
+++ b/src/main/java/org/infinispan/wfswarm/configuration/InfinispanConfiguration.java
@@ -3,9 +3,7 @@ package org.infinispan.wfswarm.configuration;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
 
-import org.infinispan.cdi.embedded.ConfigureCache;
 import org.infinispan.configuration.cache.CacheMode;
-import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 import org.infinispan.manager.DefaultCacheManager;
@@ -14,23 +12,17 @@ import org.infinispan.manager.EmbeddedCacheManager;
 @ApplicationScoped
 public class InfinispanConfiguration {
 
-   @ConfigureCache
-   @Produces
-   @ApplicationScoped
-   public Configuration configuration() {
-      return new ConfigurationBuilder()
-            .clustering()
-            .cacheMode(CacheMode.DIST_SYNC)
-            .build();
-   }
-
    @Produces
    @ApplicationScoped
    public EmbeddedCacheManager cacheManager() {
       GlobalConfigurationBuilder cacheManagerConfiguration = new GlobalConfigurationBuilder();
       cacheManagerConfiguration.globalJmxStatistics().allowDuplicateDomains(true).enable();
       cacheManagerConfiguration.transport().defaultTransport();
-      return new DefaultCacheManager(cacheManagerConfiguration.build());
+
+      ConfigurationBuilder cacheConfiguration = new ConfigurationBuilder();
+      cacheConfiguration.clustering().cacheMode(CacheMode.DIST_SYNC);
+
+      return new DefaultCacheManager(cacheManagerConfiguration.build(), cacheConfiguration.build());
    }
 
 }

--- a/src/main/java/org/infinispan/wfswarm/rest/InfinispanEndpoint.java
+++ b/src/main/java/org/infinispan/wfswarm/rest/InfinispanEndpoint.java
@@ -1,5 +1,6 @@
 package org.infinispan.wfswarm.rest;
 
+import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -9,6 +10,7 @@ import javax.ws.rs.core.Response;
 import org.infinispan.Cache;
 
 @Path("/infinispan")
+@ApplicationScoped
 public class InfinispanEndpoint {
 
    @Inject


### PR DESCRIPTION
Closes #2 

I enabled `CacheMode.DIST_SYNC` to all caches (by adding it to `DefaultCacheManager` constructor). Depending on your environment - I also suggest using `-Djava.net.preferIPv4Stack=true`.
