### PR TITLE
Align Infinispan version to the one in Swarm

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <packaging>war</packaging>
 
     <properties>
-        <version.infinispan>9.0.0.Final</version.infinispan>
+        <version.infinispan>8.2.4.Final</version.infinispan>
         <version.wildfly.swarm>2017.5.0</version.wildfly.swarm>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
@@ -62,7 +62,11 @@
         </dependency>
         <dependency>
             <groupId>org.infinispan</groupId>
-            <artifactId>infinispan-embedded</artifactId>
+            <artifactId>infinispan-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-cdi-embedded</artifactId>
         </dependency>
         <dependency>
             <groupId>javax.cache</groupId>


### PR DESCRIPTION
* Also, it shouldn't depend on the huge infinispan-embedded module which
  is a big dependency. It should depend only what it really needs.